### PR TITLE
Fixed path errors. 

### DIFF
--- a/src/privileges.sh
+++ b/src/privileges.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-source ./printProgress.sh
+src_path="$(dirname "$(readlink -f "$0")")"
+source "$src_path"/printProgress.sh
 
 printProgress "Checking for sudo privileges"
 sudo -v >/dev/null 2>&1

--- a/src/updater.sh
+++ b/src/updater.sh
@@ -8,7 +8,8 @@ NORMAL=$(tput sgr0)
 
 PKG=""
 #I call printProgress function from another shell file
-source ./printProgress.sh
+src_path="$(dirname "$(readlink -f "$0")")"
+source "$src_path"/printProgress.sh
 
 if [[ -n "$(command -v pkg)" ]]; then
     PKG="pkg"
@@ -50,7 +51,7 @@ elif [[ -n "$(command -v emerge)" ]]; then
 fi
 
 #I call this file to check sudo privileges of the user who is launching this script.
-source ./privileges.sh
+source "$src_path"/privileges.sh
 
 if [[ -n "$(command -v apt-get)" ]]; then
     PKG="apt-get"


### PR DESCRIPTION
Fix to issue https://github.com/MasterCruelty/Updater/issues/21

"." refers to the directory user is in, not the directory of where the
script is. We can get the script directory by using
"$(dirname "$(readlink -f "$0")")".

$0 is the name of the script.

readlink -f gives us the absolute path of the script which prevents
symbolic link errors.

dirname gives us the absolute path of the directory of the script.